### PR TITLE
Make StartServerAsync an extension to IApplicationBuilder so you can …

### DIFF
--- a/FeatherHttp/Framework.cs
+++ b/FeatherHttp/Framework.cs
@@ -47,7 +47,7 @@ namespace FeatherHttp
             return new ApplicationBuilder(services.BuildServiceProvider());
         }
 
-        public static async Task<HttpServer> StartServerAsync(IApplicationBuilder app, params string[] addresses)
+        public static async Task<HttpServer> StartServerAsync(this IApplicationBuilder app, params string[] addresses)
         {
             var server = app.ApplicationServices.GetRequiredService<IServer>();
             var factory = app.ApplicationServices.GetService<IServiceScopeFactory>();


### PR DESCRIPTION
…call it like this:

`var server = await app.StartServerAsync("http://localhost:3000");`