### PR TITLE
Move triple backticks to new line for correct formatting of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,4 +234,5 @@ class Program
 
         await app.RunAsync();
     }
-}```
+}
+```


### PR DESCRIPTION
Superficial, but OCD folks might appreciate it - fwiw I would have expected markdown to render it correctly either way 🤷‍♂ 

before:
![image](https://user-images.githubusercontent.com/1051245/70449834-48e35380-1a68-11ea-9392-8e543959a625.png)

after:
![image](https://user-images.githubusercontent.com/1051245/70449806-3cf79180-1a68-11ea-95d8-e5b620e9fdee.png)
