### PR TITLE
Use built-in overload of `UseSerilog` to configure the logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,16 +192,17 @@ class Program
 {
     static async Task Main(string[] args)
     {
-        Log.Logger = new LoggerConfiguration()
-            .Enrich.FromLogContext()
-            .WriteTo.Console()
-            .CreateLogger();
-
         var builder = WebApplicationHost.CreateDefaultBuilder(args);
 
         builder.Configuration.AddYamlFile("appsettings.yml", optional: true);
 
-        builder.UseSerilog();
+        builder.UseSerilog((context, configuration) 
+            => configuration
+                .Enrich
+                .FromLogContext()
+                .WriteTo
+                .Console()
+            );
 
         builder.UseServiceProviderFactory(new AutofacServiceProviderFactory());
 

--- a/samples/Uber/Program.cs
+++ b/samples/Uber/Program.cs
@@ -11,16 +11,17 @@ class Program
 {
     static async Task Main(string[] args)
     {
-        Log.Logger = new LoggerConfiguration()
-            .Enrich.FromLogContext()
-            .WriteTo.Console()
-            .CreateLogger();
-
         var builder = WebApplicationHost.CreateDefaultBuilder(args);
 
         builder.Configuration.AddYamlFile("appsettings.yml", optional: true);
 
-        builder.UseSerilog();
+        builder.UseSerilog((context, configuration) 
+            => configuration
+                .Enrich
+                .FromLogContext()
+                .WriteTo
+                .Console()
+            );
 
         builder.UseServiceProviderFactory(new AutofacServiceProviderFactory());
 


### PR DESCRIPTION
Small optimization of the uber-sample.